### PR TITLE
Allow multiple --dest values

### DIFF
--- a/art/config.py
+++ b/art/config.py
@@ -31,7 +31,7 @@ class FileMapEntry:
 @dataclasses.dataclass()
 class ArtConfig:
     work_dir: str
-    dest: str
+    dests: List[str]
     name: str
     repo_url: str
     ref: Optional[str] = None

--- a/art/prepare.py
+++ b/art/prepare.py
@@ -29,7 +29,7 @@ def fork_configs_from_data(
         subcfg.update_from(cfg_data)
         subcfg.name = name or "default"
         if name:
-            subcfg.dest += "/%s" % name
+            subcfg.dests = [dest + "/%s" % name for dest in subcfg.dests]
         yield subcfg
 
 

--- a/art_tests/test_s3.py
+++ b/art_tests/test_s3.py
@@ -7,9 +7,9 @@ from art.write import _write_file
 def test_s3_acl(mocker):
     cli = get_s3_client()
     cli.put_object = cli.put_object  # avoid magic
-    with mocker.patch.object(cli, "put_object"):
-        body = io.BytesIO(b"test")
-        _write_file("s3://bukkit/key", body, options={"acl": "public-read"})
-        cli.put_object.assert_called_with(
-            Bucket="bukkit", Key="key", ACL="public-read", Body=body
-        )
+    mocker.patch.object(cli, "put_object")
+    body = io.BytesIO(b"test")
+    _write_file("s3://bukkit/key", body, options={"acl": "public-read"})
+    cli.put_object.assert_called_with(
+        Bucket="bukkit", Key="key", ACL="public-read", Body=body
+    )

--- a/art_tests/test_self.py
+++ b/art_tests/test_self.py
@@ -10,9 +10,10 @@ def test_selftest(tmpdir, source, monkeypatch):
     # Hack: Disable pytest-cov subprocess coverage...
     monkeypatch.delitem(os.environ, "COV_CORE_SOURCE", raising=False)
 
-    tmpdir = str(tmpdir)
+    dest1 = str(tmpdir.join("aaa"))
+    dest2 = str(tmpdir.join("bbb"))
     suffix = "latest"
-    args = ["--dest", tmpdir, "--suffix", suffix]
+    args = ["--dest", dest1, "--dest", dest2, "--suffix", suffix]
     if source == "local":
         art_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
         args.extend(["--local-source", art_dir])
@@ -20,4 +21,5 @@ def test_selftest(tmpdir, source, monkeypatch):
         args.extend(["--suffix-description"])
         args.extend(["--git-source", "https://github.com/valohai/art.git"])
     run_command(args)
-    assert os.path.isfile(os.path.join(tmpdir, suffix, "art.whl"))
+    for dest in (dest1, dest2):
+        assert os.path.isfile(os.path.join(dest, suffix, "art.whl"))

--- a/art_tests/test_write.py
+++ b/art_tests/test_write.py
@@ -5,7 +5,7 @@ from art.manifest import Manifest
 
 def test_dest_options(mocker, tmpdir):
     cfg = ArtConfig(
-        work_dir=str(tmpdir), dest=str(tmpdir), name="", repo_url=str(tmpdir)
+        work_dir=str(tmpdir), dests=[str(tmpdir)], name="", repo_url=str(tmpdir)
     )
     mf = Manifest(files={})
     wf = mocker.patch("art.write._write_file")


### PR DESCRIPTION
This PR enables multiple values for `--dest`, so a single build can be pushed into multiple destinations in a DRY way.
