### PR TITLE
Add support for CloudFront invalidations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.5.6
     hooks:
       - id: ruff
         args:
           - --fix
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -18,6 +18,6 @@ repos:
         args:
           - --fix=lf
   - repo: https://github.com/crate-ci/typos
-    rev: v1.19.0
+    rev: v1.23.6
     hooks:
       - id: typos

--- a/art/cloudfront.py
+++ b/art/cloudfront.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -15,8 +16,10 @@ def get_cloudfront_client() -> Any:
 
 def execute_cloudfront_invalidations(invalidations: dict[str, set[str]]) -> None:
     cf_client = get_cloudfront_client()
+    ts = int(time.time())
     for dist_id, paths in invalidations.items():
         log.info("Creating CloudFront invalidation for %s: %d paths", dist_id, len(paths))
+        caller_reference = f"art-{dist_id}-{ts}"
         inv = cf_client.create_invalidation(
             DistributionId=dist_id,
             InvalidationBatch={
@@ -24,7 +27,11 @@ def execute_cloudfront_invalidations(invalidations: dict[str, set[str]]) -> None
                     "Quantity": len(paths),
                     "Items": sorted(paths),
                 },
-                "CallerReference": "art",
+                "CallerReference": caller_reference,
             },
         )
-        log.info("Created CloudFront invalidation: %s", inv["Invalidation"]["Id"])
+        log.info(
+            "Created CloudFront invalidation with caller reference %s: %s",
+            caller_reference,
+            inv["Invalidation"]["Id"],
+        )

--- a/art/cloudfront.py
+++ b/art/cloudfront.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Separated for testing purposes
+def get_cloudfront_client() -> Any:
+    import boto3
+
+    return boto3.client("cloudfront")
+
+
+def execute_cloudfront_invalidations(invalidations: dict[str, set[str]]) -> None:
+    cf_client = get_cloudfront_client()
+    for dist_id, paths in invalidations.items():
+        log.info("Creating CloudFront invalidation for %s: %d paths", dist_id, len(paths))
+        inv = cf_client.create_invalidation(
+            DistributionId=dist_id,
+            InvalidationBatch={
+                "Paths": {
+                    "Quantity": len(paths),
+                    "Items": sorted(paths),
+                },
+                "CallerReference": "art",
+            },
+        )
+        log.info("Created CloudFront invalidation: %s", inv["Invalidation"]["Id"])

--- a/art/command.py
+++ b/art/command.py
@@ -127,6 +127,7 @@ def run_command(argv: Optional[List[str]] = None) -> None:
             process_config_postfork(context, args, forked_config)
         except Problem as p:
             ap.error(f"config {forked_config.name}: {p}")
+    context.execute_post_run_tasks()
 
 
 def clean_dest(dest: str) -> str:

--- a/art/context.py
+++ b/art/context.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 import dataclasses
 
+from art.cloudfront import execute_cloudfront_invalidations
+
 
 @dataclasses.dataclass(frozen=True)
 class ArtContext:
     dry_run: bool = False
+    _cloudfront_invalidations: dict[str, set[str]] = dataclasses.field(default_factory=dict)
+
+    def add_cloudfront_invalidation(self, dist_id: str, path: str) -> None:
+        self._cloudfront_invalidations.setdefault(dist_id, set()).add(path)
+
+    def execute_post_run_tasks(self) -> None:
+        if self._cloudfront_invalidations:
+            execute_cloudfront_invalidations(self._cloudfront_invalidations)
+            self._cloudfront_invalidations.clear()

--- a/art/context.py
+++ b/art/context.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class ArtContext:
+    dry_run: bool = False

--- a/art/s3.py
+++ b/art/s3.py
@@ -38,3 +38,7 @@ def s3_write(
         return
     s3_client.put_object(**kwargs)
     log.info("Wrote to S3 (ACL %s): %s", acl, url)
+
+    cf_distribution_id = options.get("cf-distribution-id")
+    if cf_distribution_id:
+        context.add_cloudfront_invalidation(cf_distribution_id, purl.path)

--- a/art/s3.py
+++ b/art/s3.py
@@ -1,20 +1,18 @@
 import logging
+from functools import cache
 from typing import IO, Any, Dict
 from urllib.parse import urlparse
 
 from art.context import ArtContext
 
-_s3_client = None
 log = logging.getLogger(__name__)
 
 
+@cache
 def get_s3_client() -> Any:
-    global _s3_client
-    if not _s3_client:
-        import boto3
+    import boto3
 
-        _s3_client = boto3.client("s3")
-    return _s3_client
+    return boto3.client("s3")
 
 
 def s3_write(

--- a/art/s3.py
+++ b/art/s3.py
@@ -2,6 +2,8 @@ import logging
 from typing import IO, Any, Dict
 from urllib.parse import urlparse
 
+from art.context import ArtContext
+
 _s3_client = None
 log = logging.getLogger(__name__)
 
@@ -15,7 +17,13 @@ def get_s3_client() -> Any:
     return _s3_client
 
 
-def s3_write(url: str, source_fp: IO[bytes], *, options: Dict[str, Any], dry_run: bool) -> None:
+def s3_write(
+    url: str,
+    source_fp: IO[bytes],
+    *,
+    options: Dict[str, Any],
+    context: ArtContext,
+) -> None:
     purl = urlparse(url)
     s3_client = get_s3_client()
     assert purl.scheme == "s3"
@@ -27,7 +35,7 @@ def s3_write(url: str, source_fp: IO[bytes], *, options: Dict[str, Any], dry_run
     if acl:
         kwargs["ACL"] = acl
 
-    if dry_run:
+    if context.dry_run:
         log.info("Dry-run: would write to S3 (ACL %s): %s", acl, url)
         return
     s3_client.put_object(**kwargs)

--- a/art_tests/test_s3.py
+++ b/art_tests/test_s3.py
@@ -1,9 +1,19 @@
 import io
 from unittest.mock import Mock
 
+import pytest
+from boto3 import _get_default_session
+
+from art import cloudfront
 from art.context import ArtContext
 from art.s3 import get_s3_client
 from art.write import _write_file
+
+
+@pytest.fixture(autouse=True)
+def aws_fake_credentials(monkeypatch):
+    # Makes sure we don't accidentally use real AWS credentials.
+    monkeypatch.setattr(_get_default_session()._session, "_credentials", Mock())
 
 
 def test_s3_acl(monkeypatch):
@@ -14,3 +24,29 @@ def test_s3_acl(monkeypatch):
     body = io.BytesIO(b"test")
     _write_file("s3://bukkit/key", body, options={"acl": "public-read"}, context=ArtContext())
     cli.put_object.assert_called_with(Bucket="bukkit", Key="key", ACL="public-read", Body=body)
+
+
+def test_s3_invalidate_cloudfront(monkeypatch):
+    cli = get_s3_client()
+    cli.put_object = cli.put_object  # avoid magic
+    put_object = Mock()
+    monkeypatch.setattr(cli, "put_object", put_object)
+    body = io.BytesIO(b"test")
+    options = {"acl": "public-read", "cf-distribution-id": "UWUWU"}
+    context = ArtContext()
+    _write_file("s3://bukkit/key/foo/bar", body, options=options, context=context)
+    _write_file("s3://bukkit/key/baz/quux", body, options=options, context=context)
+    _write_file("s3://bukkit/key/baz/barple", body, options=options, context=context)
+    cf_client = Mock()
+    cf_client.create_invalidation.return_value = {"Invalidation": {"Id": "AAAAA"}}
+    monkeypatch.setattr(cloudfront, "get_cloudfront_client", Mock(return_value=cf_client))
+    context.execute_post_run_tasks()
+    # Assert the 3 files get a single invalidation
+    cf_client.create_invalidation.assert_called_once()
+    call_kwargs = cf_client.create_invalidation.call_args.kwargs
+    assert call_kwargs["DistributionId"] == "UWUWU"
+    assert set(call_kwargs["InvalidationBatch"]["Paths"]["Items"]) == {
+        "/key/baz/barple",
+        "/key/baz/quux",
+        "/key/foo/bar",
+    }

--- a/art_tests/test_s3.py
+++ b/art_tests/test_s3.py
@@ -1,14 +1,16 @@
 import io
+from unittest.mock import Mock
 
 from art.context import ArtContext
 from art.s3 import get_s3_client
 from art.write import _write_file
 
 
-def test_s3_acl(mocker):
+def test_s3_acl(monkeypatch):
     cli = get_s3_client()
     cli.put_object = cli.put_object  # avoid magic
-    mocker.patch.object(cli, "put_object")
+    put_object = Mock()
+    monkeypatch.setattr(cli, "put_object", put_object)
     body = io.BytesIO(b"test")
     _write_file("s3://bukkit/key", body, options={"acl": "public-read"}, context=ArtContext())
     cli.put_object.assert_called_with(Bucket="bukkit", Key="key", ACL="public-read", Body=body)

--- a/art_tests/test_s3.py
+++ b/art_tests/test_s3.py
@@ -1,5 +1,6 @@
 import io
 
+from art.context import ArtContext
 from art.s3 import get_s3_client
 from art.write import _write_file
 
@@ -9,5 +10,5 @@ def test_s3_acl(mocker):
     cli.put_object = cli.put_object  # avoid magic
     mocker.patch.object(cli, "put_object")
     body = io.BytesIO(b"test")
-    _write_file("s3://bukkit/key", body, options={"acl": "public-read"})
+    _write_file("s3://bukkit/key", body, options={"acl": "public-read"}, context=ArtContext())
     cli.put_object.assert_called_with(Bucket="bukkit", Key="key", ACL="public-read", Body=body)

--- a/art_tests/test_write.py
+++ b/art_tests/test_write.py
@@ -1,13 +1,16 @@
+import unittest.mock
+
 import art.write
 from art.config import ArtConfig
 from art.context import ArtContext
 from art.manifest import Manifest
 
 
-def test_dest_options(mocker, tmpdir):
+def test_dest_options(monkeypatch, tmpdir):
     cfg = ArtConfig(work_dir=str(tmpdir), dests=[str(tmpdir)], name="", repo_url=str(tmpdir))
     mf = Manifest(files={})
-    wf = mocker.patch("art.write._write_file")
+    wf = unittest.mock.MagicMock()
+    monkeypatch.setattr(art.write, "_write_file", wf)
     context = ArtContext(dry_run=False)
     art.write.write(
         config=cfg,

--- a/art_tests/test_write.py
+++ b/art_tests/test_write.py
@@ -1,5 +1,6 @@
 import art.write
 from art.config import ArtConfig
+from art.context import ArtContext
 from art.manifest import Manifest
 
 
@@ -7,12 +8,13 @@ def test_dest_options(mocker, tmpdir):
     cfg = ArtConfig(work_dir=str(tmpdir), dests=[str(tmpdir)], name="", repo_url=str(tmpdir))
     mf = Manifest(files={})
     wf = mocker.patch("art.write._write_file")
+    context = ArtContext(dry_run=False)
     art.write.write(
-        cfg,
+        config=cfg,
+        context=context,
         dest="derp://foo/bar/?acl=quux",
-        path_suffix="blag",
         manifest=mf,
-        dry_run=False,
+        path_suffix="blag",
     )
     call_kwargs = wf.call_args[1]
     assert call_kwargs["options"] == {"acl": "quux"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ mypy = [
 test = [
     "build",
     "pytest-cov",
-    "pytest-mock~=3.12",
     "pytest~=8.1",
 ]
 


### PR DESCRIPTION
Add `cf-distribution-id=...` to an S3 destination URI and you're off to the races!

Fixes #11.